### PR TITLE
Fixing OC & VC masks, MIN_SPEED 13 bits, adding gets for parameters

### DIFF
--- a/Libraries/AutoDriver/AutoDriver.h
+++ b/Libraries/AutoDriver/AutoDriver.h
@@ -46,6 +46,27 @@ class AutoDriver
     void setDecKVAL(byte kvalInput);
     void setRunKVAL(byte kvalInput);
     void setHoldKVAL(byte kvalInput);
+
+    boolean getLoSpdOpt();
+    // getSyncPin
+    byte getStepMode();
+    float getMaxSpeed();
+    float getMinSpeed();
+    float getFullSpeed();
+    float getAcc();
+    float getDec();
+    byte getOCThreshold();
+    int getPWMFreqDivisor();
+    int getPWMFreqMultiplier();
+    int getSlewRate();
+    int getOCShutdown();
+    int getVoltageComp();
+    int getSwitchMode();
+    int getOscMode();
+    byte getAccKVAL();
+    byte getDecKVAL();
+    byte getRunKVAL();
+    byte getHoldKVAL();
     
     // ...and now, operational commands.
     long getPos();
@@ -83,6 +104,16 @@ class AutoDriver
     unsigned long FSCalc(float stepsPerSec);
     unsigned long intSpdCalc(float stepsPerSec);
     unsigned long spdCalc(float stepsPerSec);
+
+    // Support functions for converting from L6470 to user units
+    float accParse(unsigned long stepsPerSecPerSec);
+    float decParse(unsigned long stepsPerSecPerSec);
+    float minSpdParse(unsigned long stepsPerSec);
+    float maxSpdParse(unsigned long stepsPerSec);
+    float FSParse(unsigned long stepsPerSec);
+    float intSpdParse(unsigned long stepsPerSec);
+    float spdParse(unsigned long stepsPerSec);
+ 
     int _CSPin;
     int _resetPin;
     int _busyPin;

--- a/Libraries/AutoDriver/AutoDriverConfig.cpp
+++ b/Libraries/AutoDriver/AutoDriverConfig.cpp
@@ -37,6 +37,10 @@ void AutoDriver::configStepMode(byte stepMode)
   setParam(STEP_MODE, (unsigned long)stepModeConfig);
 }
 
+byte AutoDriver::getStepMode() {
+  return (byte)(getParam(STEP_MODE) & 0x07);
+}
+
 // This is the maximum speed the dSPIN will attempt to produce.
 void AutoDriver::setMaxSpeed(float stepsPerSecond)
 {
@@ -46,6 +50,12 @@ void AutoDriver::setMaxSpeed(float stepsPerSecond)
   
   // Now, we can set that paramter.
   setParam(MAX_SPEED, integerSpeed);
+}
+
+
+float AutoDriver::getMaxSpeed()
+{
+  return maxSpdParse(getParam(MAX_SPEED));
 }
 
 // Set the minimum speed allowable in the system. This is the speed a motion
@@ -64,12 +74,22 @@ void AutoDriver::setMinSpeed(float stepsPerSecond)
   setParam(MIN_SPEED, integerSpeed | temp);
 }
 
+float AutoDriver::getMinSpeed()
+{
+  return minSpdParse(getParam(MIN_SPEED));
+}
+
 // Above this threshold, the dSPIN will cease microstepping and go to full-step
 //  mode. 
 void AutoDriver::setFullSpeed(float stepsPerSecond)
 {
   unsigned long integerSpeed = FSCalc(stepsPerSecond);
   setParam(FS_SPD, integerSpeed);
+}
+
+float AutoDriver::getFullSpeed()
+{
+  return FSParse(getParam(FS_SPD));
 }
 
 // Set the acceleration rate, in steps per second per second. This value is
@@ -81,6 +101,11 @@ void AutoDriver::setAcc(float stepsPerSecondPerSecond)
   setParam(ACC, integerAcc);
 }
 
+float AutoDriver::getAcc()
+{
+  return accParse(getParam(ACC));
+}
+
 // Same rules as setAcc().
 void AutoDriver::setDec(float stepsPerSecondPerSecond)
 {
@@ -88,9 +113,19 @@ void AutoDriver::setDec(float stepsPerSecondPerSecond)
   setParam(DECEL, integerDec);
 }
 
+float AutoDriver::getDec()
+{
+  return accParse(getParam(DECEL));
+}
+
 void AutoDriver::setOCThreshold(byte threshold)
 {
   setParam(OCD_TH, 0x0F & threshold);
+}
+
+byte AutoDriver::getOCThreshold()
+{
+  return (byte) (getParam(OCD_TH) & 0xF);
 }
 
 // The next few functions are all breakouts for individual options within the
@@ -114,6 +149,16 @@ void AutoDriver::setPWMFreq(int divisor, int multiplier)
   setParam(CONFIG, configVal);
 }
 
+int AutoDriver::getPWMFreqDivisor()
+{
+  return (int) (getParam(CONFIG) & 0xE000);
+}
+
+int AutoDriver::getPWMFreqMultiplier()
+{
+  return (int) (getParam(CONFIG) & 0x1C00);
+}
+
 // Slew rate of the output in V/us. Can be 180, 290, or 530.
 void AutoDriver::setSlewRate(int slewRate)
 {
@@ -126,6 +171,11 @@ void AutoDriver::setSlewRate(int slewRate)
   setParam(CONFIG, configVal);
 }
 
+int AutoDriver::getSlewRate()
+{
+  return (int) (getParam(CONFIG) & 0x0300);
+}
+
 // Single bit- do we shutdown the drivers on overcurrent or not?
 void AutoDriver::setOCShutdown(int OCShutdown)
 {
@@ -135,6 +185,11 @@ void AutoDriver::setOCShutdown(int OCShutdown)
   //Now, OR in the masked incoming value.
   configVal |= (0x0800&OCShutdown);
   setParam(CONFIG, configVal);
+}
+
+int AutoDriver::getOCShutdown()
+{
+  return (int) (getParam(CONFIG) & 0x0800);
 }
 
 // Enable motor voltage compensation? Not at all straightforward- check out
@@ -149,6 +204,11 @@ void AutoDriver::setVoltageComp(int vsCompMode)
   setParam(CONFIG, configVal);
 }
 
+int AutoDriver::getVoltageComp()
+{
+  return (int) (getParam(CONFIG) & 0x0200);
+}
+
 // The switch input can either hard-stop the driver _or_ activate an interrupt.
 //  This bit allows you to select what it does.
 void AutoDriver::setSwitchMode(int switchMode)
@@ -159,6 +219,11 @@ void AutoDriver::setSwitchMode(int switchMode)
   //Now, OR in the masked incoming value.
   configVal |= (0x0100&switchMode);
   setParam(CONFIG, configVal);
+}
+
+int AutoDriver::getSwitchMode()
+{
+  return (int) (getParam(CONFIG) & 0x0100);
 }
 
 // There are a number of clock options for this chip- it can be configured to
@@ -177,6 +242,11 @@ void AutoDriver::setOscMode(int oscillatorMode)
   setParam(CONFIG, configVal);
 }
 
+int AutoDriver::getOscMode()
+{
+  return (int) (getParam(CONFIG) & 0x000F);
+}
+
 // The KVAL registers are...weird. I don't entirely understand how they differ
 //  from the microstepping, but if you have trouble getting the motor to run,
 //  tweaking KVAL has proven effective in the past. There's a separate register
@@ -187,9 +257,19 @@ void AutoDriver::setAccKVAL(byte kvalInput)
   setParam(KVAL_ACC, kvalInput);
 }
 
+byte AutoDriver::getAccKVAL()
+{
+  return (byte) getParam(KVAL_ACC);
+}
+
 void AutoDriver::setDecKVAL(byte kvalInput)
 {
   setParam(KVAL_DEC, kvalInput);
+}
+
+byte AutoDriver::getDecKVAL()
+{
+  return (byte) getParam(KVAL_DEC);
 }
 
 void AutoDriver::setRunKVAL(byte kvalInput)
@@ -197,9 +277,19 @@ void AutoDriver::setRunKVAL(byte kvalInput)
   setParam(KVAL_RUN, kvalInput);
 }
 
+byte AutoDriver::getRunKVAL()
+{
+  return (byte) getParam(KVAL_RUN);
+}
+
 void AutoDriver::setHoldKVAL(byte kvalInput)
 {
   setParam(KVAL_HOLD, kvalInput);
+}
+
+byte AutoDriver::getHoldKVAL()
+{
+  return (byte) getParam(KVAL_HOLD);
 }
 
 // Enable or disable the low-speed optimization option. With LSPD_OPT enabled,
@@ -211,4 +301,10 @@ void AutoDriver::setLoSpdOpt(boolean enable)
   if (enable) temp |= 0x00001000; // Set the LSPD_OPT bit
   else        temp &= 0xffffefff; // Clear the LSPD_OPT bit
   setParam(MIN_SPEED, temp);
+}
+
+boolean AutoDriver::getLoSpdOpt()
+{
+  unsigned long temp = getParam(MIN_SPEED);
+  return (boolean) (getParam(MIN_SPEED) & 0x00001000);
 }

--- a/Libraries/AutoDriver/AutoDriverConfig.cpp
+++ b/Libraries/AutoDriver/AutoDriverConfig.cpp
@@ -181,15 +181,15 @@ void AutoDriver::setOCShutdown(int OCShutdown)
 {
   unsigned long configVal = getParam(CONFIG);
   // This bit is CONFIG 7, mask is 0x0080
-  configVal &= ~(0x0800);
+  configVal &= ~(0x0080);
   //Now, OR in the masked incoming value.
-  configVal |= (0x0800&OCShutdown);
+  configVal |= (0x0080&OCShutdown);
   setParam(CONFIG, configVal);
 }
 
 int AutoDriver::getOCShutdown()
 {
-  return (int) (getParam(CONFIG) & 0x0800);
+  return (int) (getParam(CONFIG) & 0x0080);
 }
 
 // Enable motor voltage compensation? Not at all straightforward- check out
@@ -198,15 +198,15 @@ void AutoDriver::setVoltageComp(int vsCompMode)
 {
   unsigned long configVal = getParam(CONFIG);
   // This bit is CONFIG 5, mask is 0x0020
-  configVal &= ~(0x0200);
+  configVal &= ~(0x0020);
   //Now, OR in the masked incoming value.
-  configVal |= (0x0200&vsCompMode);
+  configVal |= (0x0020&vsCompMode);
   setParam(CONFIG, configVal);
 }
 
 int AutoDriver::getVoltageComp()
 {
-  return (int) (getParam(CONFIG) & 0x0200);
+  return (int) (getParam(CONFIG) & 0x0020);
 }
 
 // The switch input can either hard-stop the driver _or_ activate an interrupt.
@@ -305,6 +305,5 @@ void AutoDriver::setLoSpdOpt(boolean enable)
 
 boolean AutoDriver::getLoSpdOpt()
 {
-  unsigned long temp = getParam(MIN_SPEED);
-  return (boolean) (getParam(MIN_SPEED) & 0x00001000);
+  return (boolean) ((getParam(MIN_SPEED) & 0x00001000) != 0);
 }

--- a/Libraries/AutoDriver/AutoDriverSupport.cpp
+++ b/Libraries/AutoDriver/AutoDriverSupport.cpp
@@ -15,6 +15,12 @@ unsigned long AutoDriver::accCalc(float stepsPerSecPerSec)
   else return (unsigned long) long(temp);
 }
 
+
+float AutoDriver::accParse(unsigned long stepsPerSecPerSec)
+{
+    return (float) (stepsPerSecPerSec & 0x00000FFF) / 0.137438;
+}
+
 // The calculation for DEC is the same as for ACC. Value is 0x08A on boot.
 // This is a 12-bit value, so we need to make sure the value is at or below 0xFFF.
 unsigned long AutoDriver::decCalc(float stepsPerSecPerSec)
@@ -22,6 +28,11 @@ unsigned long AutoDriver::decCalc(float stepsPerSecPerSec)
   float temp = stepsPerSecPerSec * 0.137438;
   if( (unsigned long) long(temp) > 0x00000FFF) return 0x00000FFF;
   else return (unsigned long) long(temp);
+}
+
+float AutoDriver::decParse(unsigned long stepsPerSecPerSec)
+{
+    return (float) (stepsPerSecPerSec & 0x00000FFF) / 0.137438;
 }
 
 // The value in the MAX_SPD register is [(steps/s)*(tick)]/(2^-18) where tick is 
@@ -35,6 +46,12 @@ unsigned long AutoDriver::maxSpdCalc(float stepsPerSec)
   else return temp;
 }
 
+
+float AutoDriver::maxSpdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x000003FF) / 0.065536;
+}
+
 // The value in the MIN_SPD register is [(steps/s)*(tick)]/(2^-24) where tick is 
 //  250ns (datasheet value)- 0x000 on boot.
 // Multiply desired steps/s by 4.1943 to get an appropriate value for this register
@@ -44,6 +61,11 @@ unsigned long AutoDriver::minSpdCalc(float stepsPerSec)
   float temp = stepsPerSec * 4.1943;
   if( (unsigned long) long(temp) > 0x00000FFF) return 0x00000FFF;
   else return (unsigned long) long(temp);
+}
+
+float AutoDriver::minSpdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x00000FFF) / 4.1943;
 }
 
 // The value in the FS_SPD register is ([(steps/s)*(tick)]/(2^-18))-0.5 where tick is 
@@ -57,6 +79,11 @@ unsigned long AutoDriver::FSCalc(float stepsPerSec)
   else return (unsigned long) long(temp);
 }
 
+float AutoDriver::FSParse(unsigned long stepsPerSec)
+{
+    return (((float) (stepsPerSec & 0x000003FF)) + 0.5) / 0.065536;
+}
+
 // The value in the INT_SPD register is [(steps/s)*(tick)]/(2^-24) where tick is 
 //  250ns (datasheet value)- 0x408 on boot.
 // Multiply desired steps/s by 4.1943 to get an appropriate value for this register
@@ -68,6 +95,11 @@ unsigned long AutoDriver::intSpdCalc(float stepsPerSec)
   else return (unsigned long) long(temp);
 }
 
+float AutoDriver::intSpdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x00003FFF) / 4.1943;
+}
+
 // When issuing RUN command, the 20-bit speed is [(steps/s)*(tick)]/(2^-28) where tick is 
 //  250ns (datasheet value).
 // Multiply desired steps/s by 67.106 to get an appropriate value for this register
@@ -77,6 +109,11 @@ unsigned long AutoDriver::spdCalc(float stepsPerSec)
   float temp = stepsPerSec * 67.106;
   if( (unsigned long) long(temp) > 0x000FFFFF) return 0x000FFFFF;
   else return (unsigned long)temp;
+}
+
+float AutoDriver::spdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x000FFFFF) / 67.106;
 }
 
 // Much of the functionality between "get parameter" and "set parameter" is

--- a/Libraries/AutoDriver/AutoDriverSupport.cpp
+++ b/Libraries/AutoDriver/AutoDriverSupport.cpp
@@ -180,7 +180,7 @@ unsigned long AutoDriver::paramHandler(byte param, unsigned long value)
     // MinSpdCalc() function exists to convert steps/s value into a 12-bit value for this
     //  register. SetLSPDOpt() function exists to enable/disable the optimization feature.
     case MIN_SPEED: 
-      retVal = xferParam(value, 12);
+      retVal = xferParam(value, 13);
       break;
     // FS_SPD register contains a threshold value above which microstepping is disabled
     //  and the dSPIN operates in full-step mode. Defaults to 0x027 on power up.

--- a/Libraries/AutoDriver/examples/GetSetParamTest/GetSetParamTest.ino
+++ b/Libraries/AutoDriver/examples/GetSetParamTest/GetSetParamTest.ino
@@ -1,0 +1,209 @@
+#include <AutoDriver.h>
+
+/* Test sketch that just gets and sets values on a L6470 AutoDriver
+ *
+ * This is mainly a test to make sure that getting a value after setting returns
+ * the same result. This is a useful test that should be run whenever the library is changed.
+ */
+
+AutoDriver board(10, 6, 5);
+String name = "";
+unsigned long temp;
+boolean tempBool;
+byte tempByte;
+float tempFloat;
+int tempInt;
+int tempInt2;
+boolean pass = true;
+
+void pv(float v) {
+  Serial.print(name + " ");
+  Serial.println(v, DEC);
+}
+
+void test(float v1, float v2) {
+  if (v1 != v2) {
+    Serial.println("!!! " + name + " failed");
+    Serial.println(v1, DEC);
+    Serial.println(v2, DEC);
+    pass = false;
+  };
+}
+
+void test(int v1, int v2) {
+  if (v1 != v2) {
+    Serial.println("!!! " + name + " failed");
+    Serial.println(v1, DEC);
+    Serial.println(v2, DEC);
+    pass = false;
+  };
+}
+
+void setup()
+{
+  Serial.begin(9600);
+
+  // first check  board status, should be 0x2E88 on bootup, but it's not :-/
+  temp = board.getParam(STATUS);
+  Serial.print("board status: ");
+  Serial.println(temp, HEX);
+
+  Serial.println("resetting device");
+  board.resetDev();
+
+  temp = board.getStatus();
+  Serial.print("board status: ");
+  Serial.println(temp, HEX);
+
+  // set and get all configuration values here to make sure the conversions are working
+  name = "LoSpdOpt";
+  tempBool = board.getLoSpdOpt();
+  pv(tempBool);
+  tempBool = !tempBool;
+  board.setLoSpdOpt(tempBool);
+  test(tempBool, board.getLoSpdOpt());
+
+  name = "StepMode";
+  tempByte = board.getStepMode();
+  pv(tempByte);
+  tempByte = (tempByte == 0) ? 1 : 0;
+  board.configStepMode(tempByte);
+  test(tempByte, board.getStepMode());
+
+  name = "MaxSpeed";
+  tempFloat = board.getMaxSpeed();
+  pv(tempFloat);
+  // be careful about rounding
+  tempFloat = (tempFloat == 152.587890625) ? 305.17578125 : 152.587890625;
+  board.setMaxSpeed(tempFloat);
+  test(tempFloat, board.getMaxSpeed());
+
+  name = "MinSpeed";
+  tempFloat = board.getMinSpeed();
+  pv(tempFloat);
+  // be careful about rounding
+  tempFloat = (tempFloat == 23.8418788909) ? 47.6837577818 : 23.8418788909;
+  board.setMinSpeed(tempFloat);
+  test(tempFloat, board.getMinSpeed());
+
+  name = "FullSpeed";
+  tempFloat = board.getFullSpeed();
+  pv(tempFloat);
+  // be careful about rounding
+  tempFloat = (tempFloat == 160.21728515625) ? 312.80517578125 : 160.21728515625;
+  board.setFullSpeed(tempFloat);
+  test(tempFloat, board.getFullSpeed());
+
+  name = "Acc";
+  tempFloat = board.getAcc();
+  pv(tempFloat);
+  // be careful about rounding
+  tempFloat = (tempFloat == 72.76008090920998) ? 145.52016181841995 : 72.76008090920998;
+  board.setAcc(tempFloat);
+  test(tempFloat, board.getAcc());
+
+  name = "Dec";
+  tempFloat = board.getDec();
+  pv(tempFloat);
+  // be careful about rounding
+  tempFloat = (tempFloat == 72.76008090920998) ? 145.52016181841995 : 72.76008090920998;
+  board.setDec(tempFloat);
+  test(tempFloat, board.getDec());
+
+  name = "OCThreshold";
+  tempByte = board.getOCThreshold();
+  pv(tempByte);
+  tempByte = (tempByte == OC_375mA) ? OC_750mA : OC_375mA;
+  board.setOCThreshold(tempByte);
+  test(tempByte, board.getOCThreshold());
+
+  name = "PWMFreqDivisor";
+  tempInt = board.getPWMFreqDivisor();
+  tempInt2 = board.getPWMFreqMultiplier();
+  pv(tempInt);
+  tempInt = (tempInt == PWM_DIV_1) ? PWM_DIV_2 : PWM_DIV_1;
+  board.setPWMFreq(tempInt, tempInt2);
+  test(tempInt, board.getPWMFreqDivisor());
+
+  name = "PWMFreqMultiplier";
+  pv(tempInt2);
+  tempInt2 = (tempInt2 == PWM_MUL_1) ? PWM_MUL_2 : PWM_MUL_1;
+  board.setPWMFreq(tempInt, tempInt2);
+  test(tempInt2, board.getPWMFreqMultiplier());
+
+  name = "SlewRate";
+  tempInt = board.getSlewRate();
+  pv(tempInt);
+  tempInt = (tempInt == SR_180V_us) ? SR_290V_us : SR_180V_us;
+  board.setSlewRate(tempInt);
+  test(tempInt, board.getSlewRate());
+
+  name = "OCShutdown";
+  tempInt = board.getOCShutdown();
+  pv(tempInt);
+  tempInt = (tempInt == OC_SD_ENABLE) ? OC_SD_DISABLE : OC_SD_ENABLE;
+  board.setOCShutdown(tempInt);
+  test(tempInt, board.getOCShutdown());
+
+  name = "VoltageComp";
+  tempInt = board.getVoltageComp();
+  pv(tempInt);
+  tempInt = (tempInt == VS_COMP_ENABLE) ? VS_COMP_DISABLE : VS_COMP_ENABLE;
+  board.setVoltageComp(tempInt);
+  test(tempInt, board.getVoltageComp());
+
+  name = "SwitchMode";
+  tempInt = board.getSwitchMode();
+  pv(tempInt);
+  tempInt = (tempInt == SW_USER) ? VS_COMP_DISABLE : SW_HARD_STOP;
+  board.setSwitchMode(tempInt);
+  test(tempInt, board.getSwitchMode());
+
+  name = "OscMode";
+  tempInt = board.getOscMode();
+  pv(tempInt);
+  tempInt = (tempInt == INT_16MHZ) ? INT_16MHZ_OSCOUT_2MHZ : INT_16MHZ;
+  board.setOscMode(tempInt);
+  test(tempInt, board.getOscMode());
+
+  name = "AccK";
+  tempByte = board.getAccKVAL();
+  pv(tempByte);
+  tempByte = (tempByte == 0) ? 1 : 0;
+  board.setAccKVAL(tempByte);
+  test(tempByte, board.getAccKVAL());
+
+  name = "DecK";
+  tempByte = board.getDecKVAL();
+  pv(tempByte);
+  tempByte = (tempByte == 0) ? 1 : 0;
+  board.setDecKVAL(tempByte);
+  test(tempByte, board.getDecKVAL());
+
+  name = "RunK";
+  tempByte = board.getRunKVAL();
+  pv(tempByte);
+  tempByte = (tempByte == 0) ? 1 : 0;
+  board.setRunKVAL(tempByte);
+  test(tempByte, board.getRunKVAL());
+
+  name = "HoldK";
+  tempByte = board.getHoldKVAL();
+  pv(tempByte);
+  tempByte = (tempByte == 0) ? 1 : 0;
+  board.setHoldKVAL(tempByte);
+  test(tempByte, board.getHoldKVAL());
+  
+  Serial.print("Passed? ");
+  Serial.println(pass);
+}
+
+void loop()
+{
+  // do nothing
+}
+
+
+
+
+


### PR DESCRIPTION
I found a few small bugs:

- incorrect mask for OC shutdown and VC
- MIN_SPEED messages were sending 12 not 13 bits

Also added getBlah functions that correspond to the setBlah functions (e.g. getAccKVAL).

Finally, added an example that sets values, then gets values and checks that the results are the same.