### PR TITLE
Making the library compatible with Teensy

### DIFF
--- a/Libraries/AutoDriver/AutoDriver.cpp
+++ b/Libraries/AutoDriver/AutoDriver.cpp
@@ -1,3 +1,4 @@
+#include <SPI.h>
 #include "AutoDriver.h"
 #include "util/delay.h" // Turns out, using the Arduino "delay" function
                         //  in a library constructor causes the program to
@@ -26,31 +27,19 @@ AutoDriver::AutoDriver(int CSPin, int resetPin)
 
 void AutoDriver::SPIConfig()
 {
-  pinMode(11, OUTPUT); //MOSI
-  pinMode(12, INPUT);  //MISO
-  pinMode(13, OUTPUT); //SCK
+	pinMode(MOSI, OUTPUT);
+	pinMode(MISO, INPUT);
+	pinMode(SCK, OUTPUT);
   pinMode(_CSPin, OUTPUT);
   digitalWrite(_CSPin, HIGH);
   pinMode(_resetPin, OUTPUT);
   if (_busyPin != -1) pinMode(_busyPin, INPUT_PULLUP);
+ 
+  SPI.begin();
   
-    // Let's set up the SPI peripheral. SPCR first:
-  //  bit 7 - SPI interrupt (disable)
-  //  bit 6 - SPI peripheral enable (enable)
-  //  bit 5 - data order (MSb first)
-  //  bit 4 - master/slave select (master mode)
-  //  bit 3 - CPOL (active high)
-  //  bit 2 - CPHA (sample on rising edge)
-  //  bit 1:0 - data rate (8 or 16, depending on SPSR0)
-  SPCR = B01011101;
+  SPISettings settings(5000000, MSBFIRST, SPI_MODE3); 
+ 
   
-  // SPSR next- not much here, just SPI2X
-  //  bit 0 - double clock rate (no)
-  SPSR = B00000000;
-  
-  // From now on, any data written to SPDR will be pumped out over the SPI pins
-  //  and SPSR7 will be set when data TX/RX is complete. Read SPSR, then SPDR, to
-  //  clear.
   digitalWrite(_resetPin, LOW);
   _delay_ms(5);
   digitalWrite(_resetPin, HIGH);

--- a/Libraries/AutoDriver/AutoDriverSupport.cpp
+++ b/Libraries/AutoDriver/AutoDriverSupport.cpp
@@ -1,4 +1,5 @@
 #include "AutoDriver.h"
+#include <SPI.h>
 
 // AutoDriverSupport.cpp - Contains utility functions for converting real-world 
 //  units (eg, steps/s) to values usable by the dsPIN controller. These are all
@@ -261,7 +262,7 @@ unsigned long AutoDriver::xferParam(unsigned long value, byte bitLen)
   if (value > mask) value = mask;
   
   byte* bytePointer = (byte*)&value;
-  for (char i = byteLen-1; i >= 0; i--)
+  for (signed char i = byteLen-1; i >= 0; i--)
   {
     bytePointer[i] = SPIXfer(bytePointer[i]);
   }
@@ -269,20 +270,16 @@ unsigned long AutoDriver::xferParam(unsigned long value, byte bitLen)
   return value;
 }
 
-// SPIXfer() accepts a byte  and a number of bytes to transfer to
-//  the L6470, then returns any data received. A *very* important
-//  note regarding chip select- holding the CS line low results in data being
-//  shifted THROUGH the chip, not into it. To latch data, CS must be released
-//  after each byte. I can't find a reference to this in the datasheet, which
-//  is AWESOME, and I've personally discovered it at least twice.
+SPISettings settings(5000000, MSBFIRST, SPI_MODE3);
+
 byte AutoDriver::SPIXfer(byte data)
 {
   byte rxData;
+  SPI.beginTransaction(settings);
   digitalWrite(_CSPin, LOW);
-  SPDR = data;
-  while (!(SPSR&(1<<SPIF)));
-  rxData = SPSR;
-  rxData = SPDR;
+  rxData = SPI.transfer(data); 
   digitalWrite(_CSPin, HIGH);
+  SPI.endTransaction();
   return rxData;
 }
+


### PR DESCRIPTION
Hi!

[I came across a simple fix that will make the library compatible with Teensy microcontrollers.](https://forum.pjrc.com/threads/28094-L6470-AutoDriver-stepper-driver-and-the-Teensy-3-1?p=69752&viewfull=1#post69752) Simply declaring all chars explicitly as signed will fix it. 

I also changed everything to use standard SPI library calls so it's possible to use other SPI devices with different settings, too.